### PR TITLE
replacing the sc_wrap function that was misbehaving

### DIFF
--- a/IBufWr.cpp
+++ b/IBufWr.cpp
@@ -128,7 +128,8 @@ void IBufWr_next(IBufWr *unit, int n) {
       }
     } else {
       // round the next index and make sure it is in the buffer's boundaries
-      long index = sc_wrap(static_cast<long>(indexBuffer), 0, bufFrames);
+      auto index = static_cast<long>(indexBuffer);
+      while(index >= bufFrames) index -= bufFrames; //sc_wrap was misbehaving
 
       if (previousIndex < 0) { // if it is the first index to write, resets the
                                // averaging and the values


### PR DESCRIPTION
it seems that I was getting crash with this code:

```
b = Buffer.alloc(s, 10);

(
{var idx = (Sweep.ar(1) * 44100);//.poll(100);
	IBufWr.ar(DC.ar(0),b,idx,0,0);
	Line.ar(dur: 0.001,doneAction: 2)
}.play
)
```

After investigation, the sc_wrap utit was actually wrapping around 1 to max and not 0 to max-1...  @madskjeldgaard refactor introduced its use and I reckon he didn't have that problem?